### PR TITLE
Feature/Entity desc

### DIFF
--- a/demo/app/app.module.ts
+++ b/demo/app/app.module.ts
@@ -29,6 +29,7 @@ import { DemoMapComponent } from './components/demo-map/demo-map.component';
 import { MaxValidatorDirective } from './shared/settings-form/max-validtor.directive';
 import { MinValidatorDirective } from './shared/settings-form/min-validator.directive';
 import { MapsLayerComponent } from './components/maps-layer/maps-layer.component';
+import { ModelLayerComponent } from "./components/model-layer/ellipse-layer/model-layer.component";
 
 
 @NgModule({
@@ -47,6 +48,7 @@ import { MapsLayerComponent } from './components/maps-layer/maps-layer.component
     StaticCircleLayerComponent,
     EventTestLayerComponent,
     ArcLayerComponent,
+    ModelLayerComponent,
     SymbologyLayerComponent,
     PointLayerComponent,
     TracksDialogComponent,

--- a/demo/app/components/demo-map/demo-map.component.html
+++ b/demo/app/components/demo-map/demo-map.component.html
@@ -6,6 +6,7 @@
     </ac-map-layer-provider>
     <tracks-layer #layer [show]="appSettingsService.showTracksLayer"
                   [realData]="tracksRealData"></tracks-layer>
+    <!--<model-layer></model-layer>-->
     <!--<maps-layer></maps-layer>-->
     <!--<dynamic-ellipse-layer #layer></dynamic-ellipse-layer>-->
     <!--<ellipse-layer #layer></ellipse-layer>-->

--- a/demo/app/components/model-layer/ellipse-layer/model-layer.component.html
+++ b/demo/app/components/model-layer/ellipse-layer/model-layer.component.html
@@ -1,0 +1,12 @@
+<ac-layer acFor="let model of models$" [context]="this" [show]="show">
+  <ac-entity-desc props="{
+        position : model.position,
+        orientation : this.getOrientation(model),
+        model : {
+            uri : this.url,
+            minimumPixelSize : 128,
+            maximumScale : 20000
+        }}
+">
+  </ac-entity-desc>
+</ac-layer>

--- a/demo/app/components/model-layer/ellipse-layer/model-layer.component.ts
+++ b/demo/app/components/model-layer/ellipse-layer/model-layer.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { Observable } from 'rxjs';
+import { TracksDataProvider } from "../../../../utils/services/dataProvider/tracksDataProvider.service";
+import { AcLayerComponent } from "../../../../../src/components/ac-layer/ac-layer.component";
+import { AcNotification } from "../../../../../src/models/ac-notification";
+
+@Component({
+  selector: 'model-layer',
+  templateUrl: 'model-layer.component.html',
+  styleUrls: ['model-layer.component.css'],
+  providers: [TracksDataProvider]
+})
+export class ModelLayerComponent implements OnInit {
+  readonly url: string = 'https://cesiumjs.org/Cesium/Apps/SampleData/models/CesiumAir/Cesium_Air.glb';
+  @ViewChild(AcLayerComponent) readonly layer:AcLayerComponent;
+  readonly Cesium = Cesium;
+
+  models$:Observable<AcNotification>;
+  show = true;
+
+  constructor(private tracksDataProvider:TracksDataProvider) {
+  }
+
+  getOrientation(model: any) {
+    var heading = Cesium.Math.toRadians(135);
+    var pitch = 0;
+    var roll = 0;
+    var hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
+
+    return Cesium.Transforms.headingPitchRollQuaternion(model.position, hpr);
+  }
+
+  ngOnInit() {
+    this.models$ = this.tracksDataProvider.get();
+  }
+
+  removeAll() {
+    this.layer.removeAll();
+  }
+
+  setShow($event) {
+    this.show = $event
+  }
+}

--- a/demo/utils/services/dataProvider/tracksDataProvider.service.ts
+++ b/demo/utils/services/dataProvider/tracksDataProvider.service.ts
@@ -17,15 +17,6 @@ export class TracksDataProvider {
 			this._socket.on('birds', (data) => {
 				data.forEach(
 					(acNotification) => {
-						let action;
-						if (acNotification.action === 'ADD_OR_UPDATE') {
-							action = ActionType.ADD_UPDATE;
-						}
-						else if (acNotification.action === 'DELETE') {
-							action = ActionType.DELETE;
-						}
-						acNotification.actionType = action;
-						acNotification.entity = convertToCesiumObj(acNotification.entity);
 						observer.next(acNotification);
 					});
 			});

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bundle": "npm run cleanup && npm run lint && npm run ngc && npm run rollup",
     "build-demo": "rimraf dist && webpack --config config/webpack.dev.js --progress --profile --bail",
     "test-server": "node demo/performance-server/server.js",
-    "server": "nodemon --exec ./node_modules/.bin/ts-node -- ./demo/server/src/main.ts",
+    "server": "nodemon --exec ts-node -- ./demo/server/src/main.ts",
     "compile-docs": "rimraf docs && compodoc -p src/tsconfig.compodoc.json -d docs -n \"Angular 2 Cesium\"",
     "serve-docs": "compodoc -s -d ./docs -r 4200",
     "compileNserve-docs": "npm run compile-docs && npm run serve-docs",

--- a/src/angular-cesium.module.ts
+++ b/src/angular-cesium.module.ts
@@ -32,6 +32,7 @@ import { AcCircleComponent } from './components/ac-circle/ac-circle.component';
 import { AcArcComponent } from './components/ac-arc/ac-arc.component';
 import { AcDefaultPlonterComponent } from './components/ac-default-plonter/ac-default-plonter.component';
 import { ViewersManagerService } from './services/viewers-service/viewers-manager.service';
+import { AcEntityDescComponent } from "./components/ac-entity-desc/ac-entity-desc.component";
 
 @NgModule({
 	imports: [
@@ -49,6 +50,7 @@ import { ViewersManagerService } from './services/viewers-service/viewers-manage
 		AcDynamicEllipseDescComponent,
 		AcDynamicPolylineDescComponent,
 		AcStaticPolygonDescComponent,
+		AcEntityDescComponent,
 		PixelOffsetPipe,
 		RadiansToDegreesPipe,
 		AcStaticCircleDescComponent,
@@ -76,6 +78,7 @@ import { ViewersManagerService } from './services/viewers-service/viewers-manage
 		AcDynamicEllipseDescComponent,
 		AcDynamicPolylineDescComponent,
 		AcStaticPolygonDescComponent,
+		AcEntityDescComponent,
 		AcLayerComponent,
 		AcStaticCircleDescComponent,
 		AcDynamicCircleDescComponent,

--- a/src/angular-cesium.module.ts
+++ b/src/angular-cesium.module.ts
@@ -32,7 +32,7 @@ import { AcCircleComponent } from './components/ac-circle/ac-circle.component';
 import { AcArcComponent } from './components/ac-arc/ac-arc.component';
 import { AcDefaultPlonterComponent } from './components/ac-default-plonter/ac-default-plonter.component';
 import { ViewersManagerService } from './services/viewers-service/viewers-manager.service';
-import { AcEntityDescComponent } from "./components/ac-entity-desc/ac-entity-desc.component";
+import { AcEntityDescComponent } from './components/ac-entity-desc/ac-entity-desc.component';
 
 @NgModule({
 	imports: [

--- a/src/components/ac-entity-desc/ac-entity-desc.component.ts
+++ b/src/components/ac-entity-desc/ac-entity-desc.component.ts
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+import { CesiumProperties } from '../../services/cesium-properties/cesium-properties.service';
+import { ComputationCache } from '../../services/computation-cache/computation-cache.service';
+import { LayerService } from '../../services/layer-service/layer-service.service';
+import { BasicDesc } from '../../services/basic-desc/basic-desc.service';
+import { EntityDrawerService } from "../../services/drawers/entity-drawer/entity-drawer.service";
+
+/**
+ *  This is an implementation of a Cesium entity.
+ *
+ *  __Usage :__
+ *  ```
+ *    &lt;ac-dynamic-ellipse-desc props="{
+ *      center: data.position,
+ *      semiMajorAxis:250000.0,
+ *      semiMinorAxis:400000.0,
+ *      rotation : 0.785398,
+ *      width:3, // Optional
+ *      granularity:0.08 // Optional
+ *      }"&gt;
+ *    ">
+ *    &lt;/ac-dynamic-ellipse-desc&gt;
+ *  ```
+ *  __param:__ {Cesium.Cartesian3} center
+ *  __param:__ {number} semiMajorAxis
+ *  __param:__ {number} semiMinorAxis
+ *  __param:__ {number} rotation
+ *   __param__: {number} [1] width
+ *   __param__: {number} [0.003] granularity
+ */
+@Component({
+	selector: 'ac-entity-desc',
+	template: '',
+})
+export class AcEntityDescComponent extends BasicDesc {
+	constructor(entityDrawer: EntityDrawerService, layerService: LayerService,
+	            computationCache: ComputationCache, cesiumProperties: CesiumProperties) {
+		super(entityDrawer, layerService, computationCache, cesiumProperties);
+	}
+}

--- a/src/components/ac-entity-desc/ac-entity-desc.component.ts
+++ b/src/components/ac-entity-desc/ac-entity-desc.component.ts
@@ -3,7 +3,7 @@ import { CesiumProperties } from '../../services/cesium-properties/cesium-proper
 import { ComputationCache } from '../../services/computation-cache/computation-cache.service';
 import { LayerService } from '../../services/layer-service/layer-service.service';
 import { BasicDesc } from '../../services/basic-desc/basic-desc.service';
-import { EntityDrawerService } from "../../services/drawers/entity-drawer/entity-drawer.service";
+import { EntityDrawerService } from '../../services/drawers/entity-drawer/entity-drawer.service';
 
 /**
  *  This is an implementation of a Cesium entity.

--- a/src/components/ac-entity-desc/ac-entity-desc.component.ts
+++ b/src/components/ac-entity-desc/ac-entity-desc.component.ts
@@ -10,23 +10,18 @@ import { EntityDrawerService } from '../../services/drawers/entity-drawer/entity
  *
  *  __Usage :__
  *  ```
- *    &lt;ac-dynamic-ellipse-desc props="{
- *      center: data.position,
- *      semiMajorAxis:250000.0,
- *      semiMinorAxis:400000.0,
- *      rotation : 0.785398,
- *      width:3, // Optional
- *      granularity:0.08 // Optional
+ *    &lt;ac-entity-desc props="{
+ *		        position : model.position,
+ *       orientation : this.getOrientation(model),
+ *       model : {
+ *           uri : this.url,
+ *           minimumPixelSize : 128,
+ *           maximumScale : 20000
+ *       }}
  *      }"&gt;
  *    ">
  *    &lt;/ac-dynamic-ellipse-desc&gt;
  *  ```
- *  __param:__ {Cesium.Cartesian3} center
- *  __param:__ {number} semiMajorAxis
- *  __param:__ {number} semiMinorAxis
- *  __param:__ {number} rotation
- *   __param__: {number} [1] width
- *   __param__: {number} [0.003] granularity
  */
 @Component({
 	selector: 'ac-entity-desc',

--- a/src/components/ac-map/ac-map.component.ts
+++ b/src/components/ac-map/ac-map.component.ts
@@ -35,7 +35,7 @@ import { EntityDrawerService } from '../../services/drawers/entity-drawer/entity
 			<ng-content></ng-content>
 	`,
 	providers: [CesiumService, BillboardDrawerService, CesiumEventBuilder, MapEventsManagerService, PlonterService,
-	LabelDrawerService, DynamicPolylineDrawerService, DynamicEllipseDrawerService, PointDrawerService, ArcDrawerService
+	LabelDrawerService, DynamicPolylineDrawerService, DynamicEllipseDrawerService, PointDrawerService, ArcDrawerService,
 	EntityDrawerService]
 })
 export class AcMapComponent implements OnChanges, OnInit {

--- a/src/components/ac-map/ac-map.component.ts
+++ b/src/components/ac-map/ac-map.component.ts
@@ -11,6 +11,7 @@ import { DynamicEllipseDrawerService } from '../../services/drawers/ellipse-draw
 import { PointDrawerService } from '../../services/drawers/point-drawer/point-drawer.service';
 import { ArcDrawerService } from '../../services/drawers/arc-drawer/arc-drawer.service';
 import { ViewersManagerService } from '../../services/viewers-service/viewers-manager.service';
+import { EntityDrawerService } from "../../services/drawers/entity-drawer/entity-drawer.service";
 
 /**
  * This is a map implementation, creates the cesium map.
@@ -34,7 +35,8 @@ import { ViewersManagerService } from '../../services/viewers-service/viewers-ma
 			<ng-content></ng-content>
 	`,
 	providers: [CesiumService, BillboardDrawerService, CesiumEventBuilder, MapEventsManagerService, PlonterService,
-	LabelDrawerService, DynamicPolylineDrawerService, DynamicEllipseDrawerService, PointDrawerService, ArcDrawerService]
+	LabelDrawerService, DynamicPolylineDrawerService, DynamicEllipseDrawerService, PointDrawerService, ArcDrawerService
+	EntityDrawerService]
 })
 export class AcMapComponent implements OnChanges, OnInit {
 	private static readonly DEFAULT_MINIMUM_ZOOM = 1.0;

--- a/src/components/ac-map/ac-map.component.ts
+++ b/src/components/ac-map/ac-map.component.ts
@@ -11,7 +11,7 @@ import { DynamicEllipseDrawerService } from '../../services/drawers/ellipse-draw
 import { PointDrawerService } from '../../services/drawers/point-drawer/point-drawer.service';
 import { ArcDrawerService } from '../../services/drawers/arc-drawer/arc-drawer.service';
 import { ViewersManagerService } from '../../services/viewers-service/viewers-manager.service';
-import { EntityDrawerService } from "../../services/drawers/entity-drawer/entity-drawer.service";
+import { EntityDrawerService } from '../../services/drawers/entity-drawer/entity-drawer.service';
 
 /**
  * This is a map implementation, creates the cesium map.

--- a/src/services/drawers/entity-drawer/entity-drawer.service.ts
+++ b/src/services/drawers/entity-drawer/entity-drawer.service.ts
@@ -1,0 +1,40 @@
+import { CesiumService } from '../../cesium/cesium.service';
+import { Injectable } from '@angular/core';
+import { SimpleDrawerService } from '../simple-drawer/simple-drawer.service';
+
+/**
+ *  This drawer is responsible for creating an entity, this should be used only if you need to create some kind of Cesium object
+ *  we do not provide an API for (e.g, a 3d model).
+ *  Caution, using entities is not adviced if performence is a concern.
+ */
+@Injectable()
+export class EntityDrawerService extends SimpleDrawerService {
+  constructor(cesiumService:CesiumService) {
+    super(Map, cesiumService);
+  }
+
+  protected initialize(): void {
+  }
+
+  add(cesiumProps:any, ...moreProps):any {
+    const entity = this.cesiumService.getViewer().entities.add(cesiumProps);
+
+    this._cesiumCollection.set(entity.id, entity);
+
+    return entity;
+  }
+
+  remove(entity:any):any {
+    this._cesiumCollection.delete(entity.id);
+
+    return this.cesiumService.getViewer().entities.remove(entity);
+  }
+
+  removeAll():any {
+    for (let entity of this._cesiumCollection.values()) {
+      this.cesiumService.getViewer().entities.remove(entity);
+    }
+
+    this._cesiumCollection = new Map();
+  }
+}

--- a/src/services/drawers/entity-drawer/entity-drawer.service.ts
+++ b/src/services/drawers/entity-drawer/entity-drawer.service.ts
@@ -5,7 +5,7 @@ import { SimpleDrawerService } from '../simple-drawer/simple-drawer.service';
 /**
  *  This drawer is responsible for creating an entity, this should be used only if you need to create some kind of Cesium object
  *  we do not provide an API for (e.g, a 3d model).
- *  Caution, using entities is not adviced if performence is a concern.
+ *  Caution, using entities is not adviced if performance is a concern.
  */
 @Injectable()
 export class EntityDrawerService extends SimpleDrawerService {

--- a/src/services/drawers/entity-drawer/entity-drawer.service.ts
+++ b/src/services/drawers/entity-drawer/entity-drawer.service.ts
@@ -9,14 +9,14 @@ import { SimpleDrawerService } from '../simple-drawer/simple-drawer.service';
  */
 @Injectable()
 export class EntityDrawerService extends SimpleDrawerService {
-  constructor(cesiumService:CesiumService) {
+  constructor(cesiumService: CesiumService) {
     super(Map, cesiumService);
   }
 
   protected initialize(): void {
   }
 
-  add(cesiumProps:any, ...moreProps):any {
+  add(cesiumProps: any, ...moreProps): any {
     const entity = this.cesiumService.getViewer().entities.add(cesiumProps);
 
     this._cesiumCollection.set(entity.id, entity);
@@ -24,14 +24,14 @@ export class EntityDrawerService extends SimpleDrawerService {
     return entity;
   }
 
-  remove(entity:any):any {
+  remove(entity: any): any {
     this._cesiumCollection.delete(entity.id);
 
     return this.cesiumService.getViewer().entities.remove(entity);
   }
 
-  removeAll():any {
-    for (let entity of this._cesiumCollection.values()) {
+  removeAll(): any {
+    for (const entity of this._cesiumCollection.values()) {
       this.cesiumService.getViewer().entities.remove(entity);
     }
 

--- a/src/services/drawers/simple-drawer/simple-drawer.service.ts
+++ b/src/services/drawers/simple-drawer/simple-drawer.service.ts
@@ -6,12 +6,16 @@ import { CesiumService } from '../../cesium/cesium.service';
 export abstract class SimpleDrawerService {
 	protected _showAll = true;
 
-	private _cesiumCollection: any;
+	protected _cesiumCollection: any;
 	private _propsAssigner: Function;
 
-	constructor(drawerType: any, cesiumService: CesiumService) {
+	constructor(drawerType: any, protected cesiumService: CesiumService) {
 		this._cesiumCollection = new drawerType();
-		cesiumService.getScene().primitives.add(this._cesiumCollection);
+		this.initialize();
+	}
+
+	protected initialize(): void {
+		this.cesiumService.getScene().primitives.add(this._cesiumCollection);
 	}
 
 	setPropsAssigner(assigner: Function) {


### PR DESCRIPTION
Hi again, I've add an implementation for Angular general entity: 

Why:

1. There are times when a user needs to use some kind of future that we have yet to implement (e.g, 3d model, ground primitive, etc..), using the general Entity could be a way to work around this until we implement the desired feature.

2. In my particular case I needed a 3d model, so I started looking into how to implement it with a primitive, this is possible and not hard but it is only semi-updatable (can only change model matrix)
The only way of creating an updateable 3d model is by using an entity.

How:

In order to achieve this I needed to change the default drawer we use, `EntityCollection` does not allow adding more collections into it, so the default way the drawers work cant work here, instead I pass the Map constractor as the collection to the basicDrawer and I add all entities to the viewer.entities collection and manage the deletion of entities by layer by myself.
