### PR TITLE
Fix unit test config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.57
+### Fixes
+* Fixed demo app unit tests
+* Updated README with instructions for including Cesium scripts in test config
+
 ## 0.56
 ### Features
 * Added `onDrag` hook into the `ac-toolbar` component.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ for webpack users try [this](https://cesiumjs.org/2016/01/26/Cesium-and-Webpack/
 	    "./node_modules/cesium/Build/Cesium/Cesium.js"
 	  ],
   ```
+ + To avoid `ReferenceError: Cesium is not defined` errors when running unit tests, add Cesium scripts
+in `.angular-cli.json` or `angular.json`(Angular >=6) file in the test block of the app configuration.
+Note that in the example below, only the relevant sections and values are shown.
+
+  ```javascript
+  "projects": {
+      "angular-cesium-demo": {
+        "architect": {
+          "test": {
+            "scripts": [
+                "./node_modules/cesium/Build/Cesium/Cesium.js"
+              ],
+          }
+        }
+      }
+  }
+  ```
+  
 + Add `CESIUM_BASE_URL` in `main.ts` file, before bootstrapping:
   ```javascript
     // ...

--- a/angular.json
+++ b/angular.json
@@ -21,16 +21,21 @@
             "assets": [
               "demo/favicon.ico",
               "demo/assets",
-              { "glob": "**/*", "input": "./node_modules/cesium/Build/Cesium", "output": "./assets/cesium" }
-
+              {
+                "glob": "**/*",
+                "input": "./node_modules/cesium/Build/Cesium",
+                "output": "./assets/cesium"
+              }
             ],
             "styles": [
               "demo/styles.css",
               "demo/app/utils/loading.css",
               "./node_modules/cesium/Build/Cesium/Widgets/widgets.css"
             ],
-            "scripts": [ "./node_modules/cesium/Build/Cesium/Cesium.js",
-              "./node_modules/socket.io-client/dist/socket.io.js"]
+            "scripts": [
+              "./node_modules/cesium/Build/Cesium/Cesium.js",
+              "./node_modules/socket.io-client/dist/socket.io.js"
+            ]
           },
           "configurations": {
             "production": {
@@ -83,26 +88,19 @@
             "polyfills": "demo/polyfills.ts",
             "tsConfig": "demo/tsconfig.spec.json",
             "karmaConfig": "demo/karma.conf.js",
-            "styles": [
-              "demo/styles.css"
+            "styles": ["demo/styles.css"],
+            "scripts": [
+              "./node_modules/cesium/Build/Cesium/Cesium.js",
+              "./node_modules/socket.io-client/dist/socket.io.js"
             ],
-            "scripts": [],
-            "assets": [
-              "demo/favicon.ico",
-              "demo/assets"
-            ]
+            "assets": ["demo/favicon.ico", "demo/assets"]
           }
         },
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": [
-              "demo/tsconfig.app.json",
-              "demo/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "tsConfig": ["demo/tsconfig.app.json", "demo/tsconfig.spec.json"],
+            "exclude": ["**/node_modules/**"]
           }
         }
       }
@@ -128,9 +126,7 @@
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
             "tsConfig": "e2e/tsconfig.e2e.json",
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "exclude": ["**/node_modules/**"]
           }
         }
       }
@@ -163,9 +159,7 @@
               "projects/angular-cesium/tsconfig.lib.json",
               "projects/angular-cesium/tsconfig.spec.json"
             ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "exclude": ["**/node_modules/**"]
           }
         }
       }

--- a/demo/app/app.component.spec.ts
+++ b/demo/app/app.component.spec.ts
@@ -1,12 +1,11 @@
 import { async, TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
+import { AppModule } from './app.module';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        AppComponent
-      ],
+      imports: [AppModule]
     }).compileComponents();
   }));
 
@@ -14,18 +13,5 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();
-  });
-
-  it(`should have as title 'newlib-angular-cesium'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('newlib-angular-cesium');
-  });
-
-  it('should render title in a h1 tag', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Welcome to newlib-angular-cesium!');
   });
 });

--- a/demo/app/layout/main-navbar/main-navbar.component.spec.ts
+++ b/demo/app/layout/main-navbar/main-navbar.component.spec.ts
@@ -1,6 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MainNavbarComponent } from './main-navbar.component';
+import { AppMaterialModule } from 'demo/app/app.material.module';
+import { AngularCesiumWidgetsModule } from 'angular-cesium';
+import { AppSettingsService } from 'demo/app/services/app-settings-service/app-settings-service';
 
 describe('MainNavbarComponent', () => {
   let component: MainNavbarComponent;
@@ -8,9 +11,10 @@ describe('MainNavbarComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ MainNavbarComponent ]
-    })
-    .compileComponents();
+      imports: [AppMaterialModule, AngularCesiumWidgetsModule],
+      declarations: [MainNavbarComponent],
+      providers: [AppSettingsService]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/demo/app/layout/sidenav-toolbar/sidenav-toolbar.component.spec.ts
+++ b/demo/app/layout/sidenav-toolbar/sidenav-toolbar.component.spec.ts
@@ -1,6 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SidenavToolbarComponent } from './sidenav-toolbar.component';
+import { AppMaterialModule } from 'demo/app/app.material.module';
+import { AppSettingsService } from 'demo/app/services/app-settings-service/app-settings-service';
 
 describe('SidenavToolbarComponent', () => {
   let component: SidenavToolbarComponent;
@@ -8,9 +10,10 @@ describe('SidenavToolbarComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SidenavToolbarComponent ]
-    })
-    .compileComponents();
+      imports: [AppMaterialModule],
+      declarations: [SidenavToolbarComponent],
+      providers: [AppSettingsService]
+    }).compileComponents();
   }));
 
   beforeEach(() => {


### PR DESCRIPTION
Now, running: `ng test angular-cesium-demo` will result in a passing test suite.

Added scripts section to the test config in the angular.json file. This avoids the issue where the Cesium
variable is undefined in the tests.

Removed obsolete tests from the app.component.spec.ts file because the elements that they were testing no longer exist in the AppComponent.

Updated the README file to indicate to future users of the library that they need to include the Cesium
scripts in the test config in order for the tests to know about the Cesium global var.

<!--
  Thanks for filing a pull request on Angular Cesium!
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all changes are documented in CHANGESLOG.md and README.md
