### PR TITLE
Add ng-add schematic

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Focusing on high performance with easy usage.
 Check out our [Demo](http://www.angular-cesium.com) that contains small app built with angular-cesium and our blog post [Intro to angular-cesium](https://cesium.com/blog/2019/03/28/angular-cesium/).
 
 ## Getting started
+#### If you are using Angular CLI, you can add the angular-cesium library using schematics
++ add `angular-cesium`:
+  ```bash
+  $ ng add angular-cesium
+  ```
+
 #### For existing project just install angular-cesium
 + install `angular-cesium`:
   ```bash

--- a/projects/angular-cesium/package.json
+++ b/projects/angular-cesium/package.json
@@ -25,5 +25,11 @@
   },
   "optionalDependencies": {
     "heatmap.js": "^2.0.5"
-  }
+  },
+  "scripts": {
+    "build": "..\\..\\node_modules\\.bin\\tsc -p tsconfig.schematics.json",
+    "copy:collection": "copy schematics\\collection.json ..\\..\\dist\\angular-cesium\\schematics\\collection.json",
+    "postbuild": "npm run copy:collection"
+  },
+  "schematics": ".\\schematics\\collection.json"
 }

--- a/projects/angular-cesium/schematics/collection.json
+++ b/projects/angular-cesium/schematics/collection.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Add angular-cesium to the project.",
+      "factory": "./ng-add/index#ngAdd"
+    }
+  }
+}

--- a/projects/angular-cesium/schematics/ng-add/index.ts
+++ b/projects/angular-cesium/schematics/ng-add/index.ts
@@ -103,7 +103,7 @@ function addGlobalsToTarget(targetName: 'test' | 'build') {
     });
 
     tree.overwrite('angular.json', JSON.stringify(workspace, null, 2));
-  }
+  };
 }
 
 function getWorkspace(host: Tree) {
@@ -142,5 +142,5 @@ function addBaseUrlToMain() {
     recorder.insertLeft(bootstrapIndex - 1, insertion);
 
     tree.commitUpdate(recorder);
-  }
+  };
 }

--- a/projects/angular-cesium/schematics/ng-add/index.ts
+++ b/projects/angular-cesium/schematics/ng-add/index.ts
@@ -10,6 +10,8 @@ export function ngAdd(_options: any): Rule {
   return (tree: Tree, _context: SchematicContext) => {
     _context.addTask(new NodePackageInstallTask());
     addModuleImportToRootModule(tree);
+    addGlobalsToTarget('build', tree);
+    addGlobalsToTarget('test', tree);
     return tree;
   };
 }
@@ -52,13 +54,9 @@ function getProjectTargetOptions(project: WorkspaceProject, buildTarget: string)
  * Adds AngularCesium module to the root module of the specified project.
  */
 function addModuleImportToRootModule(host: Tree) {
-  const workspaceConfig = host.read('/angular.json');
-  if (!workspaceConfig) {
-    throw new SchematicsException('Could not find Angular workspace configuration');
-  }
-
-  const workspace = JSON.parse(workspaceConfig.toString());
+  const workspace = getWorkspace(host);
   const project = workspace.projects[workspace.defaultProject];
+
   const modulePath = getAppModulePath(host, getProjectMainFile(project));
   const moduleSource = getSourceFile(host, modulePath);
 
@@ -74,4 +72,40 @@ function addModuleImportToRootModule(host: Tree) {
   host.commitUpdate(recorder);
 
   return host;
+}
+
+/**
+ * Adds scripts, styles and assets to the workspace configuration file.
+ */
+function addGlobalsToTarget(targetName: 'test' | 'build', host: Tree) {
+  const workspace = getWorkspace(host);
+  const project = workspace.projects[workspace.defaultProject];
+  const targetOptions = getProjectTargetOptions(project, targetName);
+
+  addOrAppendGlobal(targetOptions.scripts, './node_modules/cesium/Build/Cesium/Cesium.js');
+  addOrAppendGlobal(targetOptions.styles, './node_modules/cesium/Build/Cesium/Widgets/widgets.css');
+  addOrAppendGlobal(targetOptions.assets,  {
+    glob: '**/*',
+    input: './node_modules/cesium/Build/Cesium',
+    output: './assets/cesium'
+  });
+
+  host.overwrite('angular.json', JSON.stringify(workspace, null, 2));
+}
+
+function getWorkspace(host: Tree) {
+  const workspaceConfig = host.read('/angular.json');
+  if (!workspaceConfig) {
+    throw new SchematicsException('Could not find Angular workspace configuration');
+  }
+
+  return JSON.parse(workspaceConfig.toString());
+}
+
+function addOrAppendGlobal(section: any[], path: any) {
+  if (!section) {
+    section = [path];
+  } else {
+    section.unshift(path);
+  }
 }

--- a/projects/angular-cesium/schematics/ng-add/index.ts
+++ b/projects/angular-cesium/schematics/ng-add/index.ts
@@ -1,0 +1,77 @@
+import { WorkspaceProject } from '@angular-devkit/core/src/workspace';
+import { Rule, SchematicContext, SchematicsException, Tree } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import { addImportToModule } from '@schematics/angular/utility/ast-utils';
+import { InsertChange } from '@schematics/angular/utility/change';
+import { getAppModulePath } from '@schematics/angular/utility/ng-ast-utils';
+import * as ts from 'typescript';
+
+export function ngAdd(_options: any): Rule {
+  return (tree: Tree, _context: SchematicContext) => {
+    _context.addTask(new NodePackageInstallTask());
+    addModuleImportToRootModule(tree);
+    return tree;
+  };
+}
+
+/** Reads file given path and returns TypeScript source file. */
+function getSourceFile(host: Tree, path: string): ts.SourceFile {
+  const buffer = host.read(path);
+  if (!buffer) {
+    throw new SchematicsException(`Could not find file for path: ${path}`);
+  }
+  return ts.createSourceFile(path, buffer.toString(), ts.ScriptTarget.Latest, true);
+}
+
+/** Looks for the main TypeScript file in the given project and returns its path. */
+function getProjectMainFile(project: WorkspaceProject): string {
+  const buildOptions = getProjectTargetOptions(project, 'build');
+
+  if (!buildOptions.main) {
+    throw new SchematicsException(`Could not find the project main file inside of the ` +
+        `workspace config (${project.sourceRoot})`);
+  }
+
+  return buildOptions.main;
+}
+
+/** Resolves the architect options for the build target of the given project. */
+function getProjectTargetOptions(project: WorkspaceProject, buildTarget: string) {
+  if (project.architect &&
+      project.architect[buildTarget] &&
+      project.architect[buildTarget].options) {
+
+    return project.architect[buildTarget].options;
+  }
+
+  throw new SchematicsException(
+    `Cannot determine project target configuration for: ${buildTarget}.`);
+}
+
+/**
+ * Adds AngularCesium module to the root module of the specified project.
+ */
+function addModuleImportToRootModule(host: Tree) {
+  const workspaceConfig = host.read('/angular.json');
+  if (!workspaceConfig) {
+    throw new SchematicsException('Could not find Angular workspace configuration');
+  }
+
+  const workspace = JSON.parse(workspaceConfig.toString());
+  const project = workspace.projects[workspace.defaultProject];
+  const modulePath = getAppModulePath(host, getProjectMainFile(project));
+  const moduleSource = getSourceFile(host, modulePath);
+
+  const changes = addImportToModule(moduleSource, modulePath, 'AngularCesiumModule.forRoot()', 'angular-cesium');
+  const recorder = host.beginUpdate(modulePath);
+
+  changes.forEach((change) => {
+    if (change instanceof InsertChange) {
+      recorder.insertLeft(change.pos, change.toAdd);
+    }
+  });
+
+  host.commitUpdate(recorder);
+
+  return host;
+}

--- a/projects/angular-cesium/tsconfig.schematics.json
+++ b/projects/angular-cesium/tsconfig.schematics.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": [
+      "es2018",
+      "dom"
+    ],
+    "declaration": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "rootDir": "schematics",
+    "outDir": "../../dist/angular-cesium/schematics",
+    "skipDefaultLibCheck": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strictNullChecks": true,
+    "target": "es6",
+    "types": [
+      "jasmine",
+      "node"
+    ]
+  },
+  "include": [
+    "schematics/**/*"
+  ],
+  "exclude": [
+    "schematics/*/files/**/*"
+  ]
+}


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Angular Cesium!
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes) #267 
- [x] Make sure all changes are documented in CHANGESLOG.md and README.md

---
- [x] Add the `AngularCesiumModule` to the app root module.
- [x] Add cesium related assets to the **angular.json** file.
- [x] Add `CESIUM_BASE_URL` in `main.ts` file.

This is a draft PR. It currently adds `AngularCesiumModule.forRoot()` when executing `ng add angular-cesium`.  To check it out:

1. Execute `npm run build` in the `projects/angular-cesium` directory
2. Execute `npm link angular-cesium` in the root folder of the project
3. Execute `ng add angular-cesium` in the root folder of the project

This will simulate adding the angular-library in the demo project.