### PR TITLE
Fix addLastPointEvent with long press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Features
 * Upgrade to Angular 11
 
+### Fixes
+* Fix `PolylinesEditorService` and `PolygonesEditorService` not adding last point when `addLastPointEvent` is `CesiumEvent.LONG_LEFT_PRESS`
+
 ## 0.66
 ### Feautures
 * Add in `MapboxStyleImageryProvider` functionality

--- a/projects/angular-cesium/src/lib/angular-cesium-widgets/services/entity-editors/polygons-editor/polygons-editor.service.ts
+++ b/projects/angular-cesium/src/lib/angular-cesium-widgets/services/entity-editors/polygons-editor/polygons-editor.service.ts
@@ -286,7 +286,25 @@ export class PolygonsEditorService {
       if (!position) {
         return;
       }
-      // position already added by addPointRegistration
+      
+      // Add last point to positions if not already added
+      const allPositions = this.getPositions(id);
+      if (!allPositions.find((cartesian) => cartesian.equals(position))) {
+        const updateValue = {
+          id,
+          positions: allPositions,
+          editMode: EditModes.CREATE,
+          updatedPosition: position,
+          editAction: EditActions.ADD_POINT,
+        };
+        this.updateSubject.next(updateValue);
+        clientEditSubject.next({
+          ...updateValue,
+          positions: this.getPositions(id),
+          points: this.getPoints(id),
+        });
+      }
+
       finishedCreate = this.switchToEditMode(
         id,
         position,

--- a/projects/angular-cesium/src/lib/angular-cesium-widgets/services/entity-editors/polyline-editor/polylines-editor.service.ts
+++ b/projects/angular-cesium/src/lib/angular-cesium-widgets/services/entity-editors/polyline-editor/polylines-editor.service.ts
@@ -268,7 +268,25 @@ export class PolylinesEditorService {
       if (!position) {
         return;
       }
-      // position already added by addPointRegistration
+
+      // Add last point to positions if not already added
+      const allPositions = this.getPositions(id);
+      if (!allPositions.find((cartesian) => cartesian.equals(position))) {
+        const updateValue = {
+          id,
+          positions: allPositions,
+          editMode: EditModes.CREATE,
+          updatedPosition: position,
+          editAction: EditActions.ADD_POINT,
+        };
+        this.updateSubject.next(updateValue);
+        clientEditSubject.next({
+          ...updateValue,
+          positions: this.getPositions(id),
+          points: this.getPoints(id),
+        });
+      }
+
       finishedCreate = this.switchToEditMode(
         id,
         position,


### PR DESCRIPTION
Fix `PolylinesEditorService` and `PolygonesEditorService` not adding last point when `addLastPointEvent` is `CesiumEvent.LONG_LEFT_PRESS`.

Fixes #380