### PR TITLE
Fix update moving point on editors that don't work properly in tablets

### DIFF
--- a/projects/angular-cesium/src/lib/angular-cesium-widgets/components/hippodrome-editor/hippodrome-editor.component.ts
+++ b/projects/angular-cesium/src/lib/angular-cesium-widgets/components/hippodrome-editor/hippodrome-editor.component.ts
@@ -159,6 +159,7 @@ export class HippodromeEditorComponent implements OnDestroy {
       case EditActions.ADD_POINT: {
         const hippodrome = this.hippodromesManager.get(update.id);
         if (update.updatedPosition) {
+          hippodrome.moveTempMovingPoint(update.updatedPosition);
           hippodrome.addPoint(update.updatedPosition);
           this.renderEditLabels(hippodrome, update);
         }

--- a/projects/angular-cesium/src/lib/angular-cesium-widgets/components/polygons-editor/polygons-editor.component.ts
+++ b/projects/angular-cesium/src/lib/angular-cesium-widgets/components/polygons-editor/polygons-editor.component.ts
@@ -177,6 +177,7 @@ export class PolygonsEditorComponent implements OnDestroy {
       case EditActions.ADD_POINT: {
         const polygon = this.polygonsManager.get(update.id);
         if (update.updatedPosition) {
+          polygon.moveTempMovingPoint(update.updatedPosition);
           polygon.addPoint(update.updatedPosition);
           this.renderEditLabels(polygon, update);
         }

--- a/projects/angular-cesium/src/lib/angular-cesium-widgets/components/polylines-editor/polylines-editor.component.ts
+++ b/projects/angular-cesium/src/lib/angular-cesium-widgets/components/polylines-editor/polylines-editor.component.ts
@@ -165,6 +165,7 @@ export class PolylinesEditorComponent implements OnDestroy {
       case EditActions.ADD_POINT: {
         const polyline = this.polylinesManager.get(update.id);
         if (update.updatedPosition) {
+          polyline.moveTempMovingPoint(update.updatedPosition);
           polyline.addPoint(update.updatedPosition);
           this.renderEditLabels(polyline, update);
         }

--- a/projects/angular-cesium/src/lib/angular-cesium-widgets/components/rectangles-editor/rectangles-editor.component.ts
+++ b/projects/angular-cesium/src/lib/angular-cesium-widgets/components/rectangles-editor/rectangles-editor.component.ts
@@ -170,6 +170,7 @@ export class RectanglesEditorComponent implements OnDestroy {
       case EditActions.ADD_POINT: {
         const rectangle = this.rectanglesManager.get(update.id);
         if (update.updatedPosition) {
+          rectangle.moveTempMovingPoint(update.updatedPosition);
           rectangle.addPoint(update.updatedPosition);
           this.renderEditLabels(rectangle, update);
         }


### PR DESCRIPTION
Update editors "moving point" when adding a new point. This is done because if the client doesn't have a mouse, the moving point doesn't update, which can cause multiple issues in creating map entities.