### PR TITLE
Fix drag mistaken for long press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.71
+### Fixes
+* Fix drag event mistaken for long press event #390
+
 ## 0.70
 ### Fixes
 * Fix update moving point on editors that don't work properly in tablets #385

--- a/projects/angular-cesium/src/lib/angular-cesium/services/map-events-mananger/event-observers/cesium-long-press-observer.ts
+++ b/projects/angular-cesium/src/lib/angular-cesium/services/map-events-mananger/event-observers/cesium-long-press-observer.ts
@@ -1,5 +1,4 @@
-import { ConnectableObservable, of as observableOf } from 'rxjs';
-
+import { ConnectableObservable, merge, of as observableOf } from 'rxjs';
 import { delay, mergeMap, publish, takeUntil } from 'rxjs/operators';
 import { CesiumPureEventObserver } from './cesium-pure-event-observer';
 import { CesiumEvent } from '../consts/cesium-event.enum';
@@ -31,7 +30,10 @@ export class CesiumLongPressObserver extends CesiumPureEventObserver {
     }
 
     const startEventObservable = this.eventFactory.get(startEvent, this.modifier);
-    const stopEventObservable = this.eventFactory.get(stopEvent, this.modifier);
+    const stopEventObservable = merge(
+      this.eventFactory.get(stopEvent, this.modifier),
+      this.eventFactory.get(CesiumEvent.MOUSE_MOVE, this.modifier) // Prevent drag mistaken for long press
+    );
 
     // publish for preventing side effect
     const longPressObservable = publish()(startEventObservable.pipe(


### PR DESCRIPTION
Fix long press events triggering event when cursor is moving away from the start position, like when the user pans the map