### PR TITLE
Change outlineArc center when use setManually in EditableCircle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.77
+### Fixes
+* Fix outlineArc center when use setManually in EditableCircle
+
 ## 0.76
 ### Fixes
 * Fix editors update subscription not being unsubscribed on destroy

--- a/projects/angular-cesium/src/lib/angular-cesium-widgets/models/editable-circle.ts
+++ b/projects/angular-cesium/src/lib/angular-cesium-widgets/models/editable-circle.ts
@@ -121,6 +121,7 @@ export class EditableCircle extends AcEntity {
     if (!this._outlineArc) {
       this.createOutlineArc();
     } else {
+      this._outlineArc.center = this.getCenter();
       this._outlineArc.radius = this.getRadius();
     }
 


### PR DESCRIPTION
Change outlineArc center when use setManually in EditableCircle. Change the radius but no the position of outlineArc

<!--
  Thanks for filing a pull request on Angular Cesium!
-->

### Checklist:
- [x] Make sure all changes are documented in CHANGESLOG.md and README.md